### PR TITLE
Ethereal-Spark-patch-1A Set up a basic Apache Spark cluster with one worker node

### DIFF
--- a/read.me
+++ b/read.me
@@ -1,0 +1,34 @@
+Ethereal-Spark-patch-1A Set up a basic Apache Spark cluster with one worker node
+
+Overview
+
+This Pull Request aims to set up a basic Apache Spark cluster with one worker node. This will allow us to test and run Spark jobs on a distributed computing environment.
+
+Tasks
+
+1: Choose a cloud provider or set up your own hardware to host the Spark cluster.
+ - You can choose any cloud provider that supports Spark, such as AWS, GCP, or Azure. Alternatively, you can set up your own hardware using commodity servers.
+ - Make sure you have enough resources (CPU, memory, storage, network) to run Spark and your workload.
+
+2: Install the latest version of Apache Spark on the cluster.
+ - Follow the official documentation for your chosen platform to install and configure Spark.
+ - Make sure you have the necessary permissions and access to install and configure Spark.
+
+3: Configure Spark to run in standalone mode with one worker node.
+ - Edit the Spark configuration files to set up the cluster in standalone mode with one worker node.
+ - Make sure the worker node has enough resources to run Spark jobs.
+
+4: Verify that Spark is running correctly by submitting a sample job.
+ - Write a simple Spark job, such as word count or data aggregation, and submit it to the Spark cluster.
+ - Verify that the job completes successfully and produces the expected output.
+
+5: Test connectivity to the Spark cluster from your development environment.
+ - Make sure you can connect to the Spark cluster from your development environment using the Spark APIs or client libraries.
+ - Test basic operations, such as submitting a job, retrieving job status, and accessing cluster metrics.
+
+6: Write documentation on how to set up and connect to the Spark cluster.
+ - Document the steps and configurations required to set up and configure the Spark cluster.
+ - Include instructions on how to connect to the cluster from a development environment and submit Spark jobs.
+
+Conclusion
+ - Once all the tasks are completed, we will have a basic Apache Spark cluster with one worker node up and running. This will allow us to test and develop Spark applications on a distributed computing environment.


### PR DESCRIPTION
- Choose a cloud provider or set up your own hardware to host the Spark cluster.
- Install the latest version of Apache Spark on the cluster.
- Configure Spark to run in standalone mode with one worker node.
- Verify that Spark is running correctly by submitting a sample job.
- Test connectivity to the Spark cluster from your development environment.
- Write documentation on how to set up and connect to the Spark cluster.
